### PR TITLE
fixed incorrectly separating by ql in crates

### DIFF
--- a/src/main/java/org/takino/mods/BulkItemsSeparated.java
+++ b/src/main/java/org/takino/mods/BulkItemsSeparated.java
@@ -39,7 +39,7 @@ public class BulkItemsSeparated implements WurmServerMod, PreInitable, Initable 
                         @Override
                         public void edit(MethodCall m) throws CannotCompileException {
                             if (m.getMethodName().equals("getItemsAsArray")) {
-                                m.replace("if ($0.getBless()!=null) $_ = $proceed($$); else $_ = org.takino.mods.BulkItemsHooks.getItemsAsArrayFiltered($0, source);");
+                                m.replace("if (($0.getBless()!=null) || $0.isCrate()) $_ = $proceed($$); else $_ = org.takino.mods.BulkItemsHooks.getItemsAsArrayFiltered($0, source);");
                             }
                         }
                     });


### PR DESCRIPTION
Oops previous version was trying to separate by ql in crates (but only when moving from another bulk container)